### PR TITLE
[fix] undeclared identifier gl_FragColor

### DIFF
--- a/screensaver.pyro/resources/shaders/GL/frag.glsl
+++ b/screensaver.pyro/resources/shaders/GL/frag.glsl
@@ -3,7 +3,9 @@
 // varying
 in vec4 v_color;
 
+out vec4 fragColor;
+
 void main()
 {
-  gl_FragColor = v_color;
+  fragColor = v_color;
 }


### PR DESCRIPTION
This fixes `CPixelShader::Compile: ERROR: 0:8: Use of undeclared identifier 'gl_FragColor'` on osx.